### PR TITLE
Add RawVector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared_vector"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/shared_vector"

--- a/fuzz/fuzz_targets/cmd.rs
+++ b/fuzz/fuzz_targets/cmd.rs
@@ -12,7 +12,7 @@ pub enum Cmd {
     Clear { idx: usize },
     Push { idx: usize, val: u32 },
     PushWithinCapacity { idx: usize, val: u32 },
-    PushSlice { idx: usize },
+    ExtendFromSlice { idx: usize },
     Pop { idx: usize },
     CloneBuffer { src_idx: usize, dst_idx: usize },
     Iter { idx: usize },
@@ -56,8 +56,8 @@ fn cmd_to_string(vec_type: &str, cmd: Cmd) -> String {
         Cmd::PushWithinCapacity { idx, val } => {
             format!("vectors[{}].push_within_capacity(Box::new({val}));", slot(idx))
         }
-        Cmd::PushSlice { idx } => {
-            format!("vectors[{}].push_slice(&[Box::new(1), Box::new(2), Box::new(3)]);", slot(idx)) 
+        Cmd::ExtendFromSlice { idx } => {
+            format!("vectors[{}].extend_from_slice(&[Box::new(1), Box::new(2), Box::new(3)]);", slot(idx)) 
         }
         Cmd::Pop { idx } => {
             format!("vectors[{}].pop();", slot(idx))

--- a/fuzz/fuzz_targets/shared_vector.rs
+++ b/fuzz/fuzz_targets/shared_vector.rs
@@ -35,8 +35,8 @@ fuzz_target!(|cmds: Vec<Cmd>| {
             Cmd::Pop { idx } => {
                 vectors[slot(idx)].pop();
             }
-            Cmd::PushSlice { idx } => {
-                vectors[slot(idx)].push_slice(&[Box::new(1), Box::new(2), Box::new(3)]);
+            Cmd::ExtendFromSlice { idx } => {
+                vectors[slot(idx)].extend_from_slice(&[Box::new(1), Box::new(2), Box::new(3)]);
             }
             Cmd::CloneBuffer { src_idx, dst_idx } => {
                 vectors[slot(dst_idx)] = vectors[slot(src_idx)].clone_buffer();

--- a/fuzz/fuzz_targets/unique_vector.rs
+++ b/fuzz/fuzz_targets/unique_vector.rs
@@ -35,8 +35,8 @@ fuzz_target!(|cmds: Vec<Cmd>| {
             Cmd::Pop { idx } => {
                 vectors[slot(idx)].pop();
             }
-            Cmd::PushSlice { idx } => {
-                vectors[slot(idx)].push_slice(&[Box::new(1), Box::new(2), Box::new(3)]);
+            Cmd::ExtendFromSlice { idx } => {
+                vectors[slot(idx)].extend_from_slice(&[Box::new(1), Box::new(2), Box::new(3)]);
             }
             Cmd::CloneBuffer { src_idx, dst_idx } => {
                 vectors[slot(dst_idx)] = vectors[slot(src_idx)].clone_buffer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod vector;
 
 pub use raw::{AtomicRefCount, BufferSize, DefaultRefCount, RefCount};
 pub use shared::{AtomicSharedVector, RefCountedVector, SharedVector};
-pub use vector::Vector;
+pub use vector::{Vector, RawVector};
 
 pub mod alloc {
     pub use allocator_api2::alloc::{AllocError, Allocator, Global};

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -5,7 +5,7 @@ use core::{mem, ptr};
 
 use crate::alloc::{AllocError, Allocator, Global};
 use crate::raw::{BufferSize, HeaderBuffer};
-use crate::vector::Vector;
+use crate::vector::{Vector, RawVector};
 use crate::{grow_amortized, AtomicRefCount, DefaultRefCount, RefCount};
 
 /// A heap allocated, atomically reference counted, immutable contiguous buffer containing elements of type `T`.
@@ -211,9 +211,11 @@ impl<T: Clone, R: RefCount, A: Allocator + Clone> RefCountedVector<T, R, A> {
             mem::forget(self);
 
             Vector {
-                data,
-                len,
-                cap,
+                raw: RawVector {
+                    data,
+                    len,
+                    cap,
+                },
                 allocator,
             }
         }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -10,128 +10,113 @@ use crate::raw::{
 use crate::shared::{AtomicSharedVector, SharedVector};
 use crate::{grow_amortized, DefaultRefCount};
 
-/// A heap allocated, mutable contiguous buffer containing elements of type `T`.
+/// A heap allocated, mutable contiguous buffer containing elements of type `T`, with manual deallocation.
 ///
 /// <svg width="280" height="120" viewBox="0 0 74.08 31.75" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="a"><stop offset="0" stop-color="#491c9c"/><stop offset="1" stop-color="#d54b27"/></linearGradient><linearGradient xlink:href="#a" id="b" gradientUnits="userSpaceOnUse" x1="6.27" y1="34.86" x2="87.72" y2="13.24" gradientTransform="translate(-2.64 -18.48)"/></defs><rect width="10.57" height="10.66" x="7.94" y="18.45" ry="1.37" fill="#3dbdaa"/><circle cx="12.7" cy="18.48" r=".79" fill="#666"/><path d="M12.7 18.48c0-3.93 7.14-1.28 7.14-5.25" fill="none" stroke="#999" stroke-width=".86" stroke-linecap="round"/><rect width="68.79" height="10.58" x="2.65" y="2.68" ry="1.37" fill="url(#b)"/><rect width="15.35" height="9.51" x="3.18" y="3.21" ry=".9" fill="#78a2d4"/><rect width="9.26" height="9.51" x="19.85" y="3.2" ry=".9" fill="#eaa577"/><rect width="9.26" height="9.51" x="29.64" y="3.22" ry=".9" fill="#eaa577"/><rect width="9.26" height="9.51" x="39.43" y="3.22" ry=".9" fill="#eaa577"/><rect width="9.26" height="9.51" x="49.22" y="3.21" ry=".9" fill="#eaa577"/><circle cx="62.84" cy="7.97" r=".66" fill="#eaa577"/><circle cx="64.7" cy="7.97" r=".66" fill="#eaa577"/><circle cx="66.55" cy="7.97" r=".66" fill="#eaa577"/></svg>
 ///
-/// Similar in principle to a `Vec<T>`.
-/// It can be converted for free into a reference counted `SharedVector<T>` or `AtomicSharedVector<T>`.
+/// See also `Vector<T, A>`.
 ///
-/// Unique and shared vectors expose similar functionality. `Vector` takes advantage of
-/// the guaranteed uniqueness at the type level to provide overall faster operations than its
-/// shared counterparts, while its memory layout makes it very cheap to convert to a shared vector
-/// (involving no allocation or copy).
+/// This container is similar to this crate's `Vector` data structure with two key difference:
+/// - It does store an allocator field. Instead, all methods that require interacting with an allocator are
+///   marked unsafe and take the allocator as parameter.
+/// - `RawVector`'s `Drop` implementation does not automatically deallocate the memory. Instead the memory
+///   must be manually deallocated via the `deallocate` method. Dropping a raw vector without deallocating it
+///   silently leaks the memory.
 ///
-/// # Internal representation
+/// `Vector<T, A>` is implemented as a thin wrapper around this type.
 ///
-/// `Vector` stores its length and capacity inline and points to the first element of the
-/// allocated buffer. Room for a header is left uninitialized before the elements so that the
-/// vector can be converted into a `SharedVector` or `AtomicSharedVector` without reallocating
-/// the storage.
-pub struct Vector<T, A: Allocator = Global> {
+/// # Use cases
+///
+/// In most cases, `Vector<T, A>` is more appropriate. However in some situations it can be beneficial to not
+/// store the allocator in the container. In complex data structures that contain many vectors, for example,
+/// it may be preferable to store the allocator once at the root of the data structure than multiple times
+/// in each of the internally managed vectors.
+pub struct RawVector<T> {
     pub(crate) data: NonNull<T>,
     pub(crate) len: BufferSize,
     pub(crate) cap: BufferSize,
-    pub(crate) allocator: A,
 }
 
-impl<T> Vector<T, Global> {
-    /// Creates an empty vector.
-    ///
-    /// This does not allocate memory.
-    pub fn new() -> Vector<T, Global> {
-        Vector {
-            data: NonNull::dangling(),
-            len: 0,
-            cap: 0,
-            allocator: Global,
-        }
+impl<T> RawVector<T> {
+    /// Creates an empty, unallocated raw vector.
+    pub fn new() -> Self {
+        RawVector { data: NonNull::dangling(), len: 0, cap: 0 }
     }
 
     /// Creates an empty pre-allocated vector with a given storage capacity.
     ///
     /// Does not allocate memory if `cap` is zero.
-    pub fn with_capacity(cap: usize) -> Vector<T, Global> {
-        Self::try_with_capacity(cap).unwrap()
-    }
-
-    /// Creates an empty pre-allocated vector with a given storage capacity.
-    ///
-    /// Does not allocate memory if `cap` is zero.
-    pub fn try_with_capacity(cap: usize) -> Result<Vector<T, Global>, AllocError> {
-        Vector::try_with_capacity_in(cap, Global)
-    }
-
-    pub fn from_slice(data: &[T]) -> Self
-    where
-        T: Clone,
-    {
-        let mut v = Self::with_capacity(data.len());
-        v.extend_from_slice(data);
-
-        v
-    }
-
-    /// Creates a vector with `n` copies of `elem`.
-    pub fn from_elem(elem: T, n: usize) -> Vector<T, Global>
-    where
-        T: Clone,
-    {
-        if n == 0 {
-            return Self::new();
-        }
-
-        let mut v = Self::with_capacity(n);
-        for _ in 0..(n - 1) {
-            v.push(elem.clone())
-        }
-
-        v.push(elem);
-
-        v
-    }
-}
-
-impl<T, A: Allocator> Vector<T, A> {
-    /// Creates an empty vector without allocating memory.
-    pub fn new_in(allocator: A) -> Self {
-        Self::try_with_capacity_in(0, allocator).unwrap()
-    }
-
-    /// Creates an empty pre-allocated vector with a given storage capacity.
-    ///
-    /// Does not allocate memory if `cap` is zero.
-    pub fn with_capacity_in(cap: usize, allocator: A) -> Self {
-        Self::try_with_capacity_in(cap, allocator).unwrap()
-    }
-
-    /// Creates an empty pre-allocated vector with a given storage capacity.
-    ///
-    /// Does not allocate memory if `cap` is zero.
-    pub fn try_with_capacity_in(cap: usize, allocator: A) -> Result<Vector<T, A>, AllocError> {
+    pub fn try_with_capacity<A: Allocator>(allocator: &A, cap: usize) -> Result<RawVector<T>, AllocError> {
         if cap == 0 {
-            return Ok(Vector {
-                data: NonNull::dangling(),
-                len: 0,
-                cap: 0,
-                allocator,
-            });
+            return Ok(RawVector::new());
         }
 
         unsafe {
-            let (base_ptr, cap) = raw::allocate_header_buffer::<T, A>(cap, &allocator)?;
+            let (base_ptr, cap) = raw::allocate_header_buffer::<T, A>(cap, allocator)?;
             let data = NonNull::new_unchecked(raw::data_ptr::<raw::Header<DefaultRefCount, A>, T>(
                 base_ptr.cast(),
             ));
-            Ok(Vector {
+            Ok(RawVector {
                 data,
                 len: 0,
                 cap: cap as BufferSize,
-                allocator,
             })
         }
     }
 
+    pub fn try_from_slice<A: Allocator>(allocator: &A, data: &[T]) -> Result<Self, AllocError>
+    where
+        T: Clone,
+    {
+        let mut v = Self::try_with_capacity(allocator, data.len())?;
+        unsafe {
+            v.extend_from_slice(allocator, data);
+        }
+
+        Ok(v)
+    }
+
+    /// Creates a raw vector with `n` clones of `elem`.
+    pub fn try_from_elem<A: Allocator>(allocator: &A, elem: T, n: usize) -> Result<Self, AllocError>
+    where
+        T: Clone,
+    {
+        if n == 0 {
+            return Ok(Self::new());
+        }
+
+        let mut v = Self::try_with_capacity(allocator, n)?;
+        unsafe {
+            for _ in 0..(n - 1) {
+                v.push(allocator, elem.clone())
+            }
+    
+            v.push(allocator, elem);    
+        }
+
+        Ok(v)
+    }
+
+    /// Clears and deallocates this raw vector, leaving it in its unallocated state.
+    ///
+    /// It is safe (no-op) to call `deallocate` on a vector that is already in its unallocated state.
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn deallocate<A: Allocator>(&mut self, allocator: &A) {
+        if self.cap == 0 {
+            return;
+        }
+
+        self.clear();
+
+        self.deallocate_buffer(allocator);
+
+        self.data = NonNull::dangling();
+        self.cap = 0;
+        self.len = 0;
+    }
 
     #[inline]
     /// Returns `true` if the vector contains no elements.
@@ -157,12 +142,6 @@ impl<T, A: Allocator> Vector<T, A> {
         (self.cap - self.len) as usize
     }
 
-    /// Returns a reference to the underlying allocator.
-    #[inline]
-    pub fn allocator(&self) -> &A {
-        &self.allocator
-    }
-
     #[inline]
     fn data_ptr(&self) -> *mut T {
         self.data.as_ptr()
@@ -186,81 +165,26 @@ impl<T, A: Allocator> Vector<T, A> {
         }
     }
 
-    unsafe fn base_ptr(&self) -> NonNull<u8> {
+    unsafe fn base_ptr<A: Allocator>(&self, _allocator: &A) -> NonNull<u8> {
         debug_assert!(self.cap > 0);
         raw::header_from_data_ptr::<Header<DefaultRefCount, A>, T>(self.data).cast()
     }
 
-    unsafe fn into_header_buffer<R>(mut self) -> HeaderBuffer<T, R, A>
-    where
-        R: RefCount,
-    {
-        debug_assert!(self.cap != 0);
-        unsafe {
-            let mut header = raw::header_from_data_ptr(self.data);
-
-            *header.as_mut() = raw::Header {
-                vec: VecHeader {
-                    len: self.len,
-                    cap: self.cap,
-                },
-                ref_count: R::new(1),
-                allocator: ptr::read(&mut self.allocator),
-            };
-
-            mem::forget(self);
-
-            HeaderBuffer::from_raw(header)
-        }
-    }
-
-    /// Make this vector immutable.
-    ///
-    /// This operation is cheap, the underlying storage does not not need
-    /// to be reallocated.
-    #[inline]
-    pub fn into_shared(self) -> SharedVector<T, A>
-    where
-        A: Allocator + Clone,
-    {
-        if self.cap == 0 {
-            return SharedVector::try_with_capacity_in(0, self.allocator.clone()).unwrap();
-        }
-        unsafe {
-            let inner = self.into_header_buffer::<DefaultRefCount>();
-            SharedVector { inner }
-        }
-    }
-
-    /// Make this vector immutable.
-    ///
-    /// This operation is cheap, the underlying storage does not not need
-    /// to be reallocated.
-    #[inline]
-    pub fn into_shared_atomic(self) -> AtomicSharedVector<T, A>
-    where
-        A: Allocator + Clone,
-    {
-        if self.cap == 0 {
-            return AtomicSharedVector::try_with_capacity_in(0, self.allocator.clone()).unwrap();
-        }
-        unsafe {
-            let inner = self.into_header_buffer::<AtomicRefCount>();
-            AtomicSharedVector { inner }
-        }
-    }
-
     /// Appends an element to the back of a collection.
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
     ///
     /// # Panics
     ///
     /// Panics if the new capacity exceeds `u32::MAX` bytes.
     #[inline]
-    pub fn push(&mut self, val: T) {
+    pub unsafe fn push<A: Allocator>(&mut self, allocator: &A, val: T) {
         let len = self.len;
         let cap = self.cap;
         if cap == len {
-            self.try_realloc_additional(1).unwrap();
+            self.try_realloc_additional(allocator, 1).unwrap();
         }
 
         unsafe {
@@ -331,15 +255,23 @@ impl<T, A: Allocator> Vector<T, A> {
     }
 
     /// Clones and appends the contents of the slice to the back of a collection.
-    pub fn extend_from_slice(&mut self, data: &[T])
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn extend_from_slice<A: Allocator>(&mut self, allocator: &A, data: &[T])
     where
         T: Clone,
     {
-        self.extend(data.iter().cloned())
+        self.extend(allocator, data.iter().cloned())
     }
 
     /// Moves all the elements of `other` into `self`, leaving `other` empty.
-    pub fn append(&mut self, other: &mut Self)
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn append<A: Allocator>(&mut self, allocator: &A, other: &mut Self)
     where
         T: Clone,
     {
@@ -347,7 +279,7 @@ impl<T, A: Allocator> Vector<T, A> {
             return;
         }
 
-        self.reserve(other.len());
+        self.try_reserve(allocator, other.len()).unwrap();
 
         unsafe {
             let src = other.data_ptr();
@@ -359,20 +291,24 @@ impl<T, A: Allocator> Vector<T, A> {
     }
 
     /// Appends the contents of an iterator to the back of a collection.
-    pub fn extend(&mut self, data: impl IntoIterator<Item = T>) {
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn extend<A: Allocator>(&mut self, allocator: &A, data: impl IntoIterator<Item = T>) {
         let mut iter = data.into_iter();
         let (min, max) = iter.size_hint();
-        self.reserve(max.unwrap_or(min));
+        self.try_reserve(allocator, max.unwrap_or(min)).unwrap();
         unsafe {
-            self.extend_until_capacity(&mut iter);
+            self.extend_within_capacity(&mut iter);
 
             for item in iter {
-                self.push(item);
+                self.push(allocator, item);
             }
         }
     }
 
-    unsafe fn extend_until_capacity(&mut self, iter: &mut impl Iterator<Item = T>) {
+    unsafe fn extend_within_capacity(&mut self, iter: &mut impl Iterator<Item = T>) {
         let n = self.remaining_capacity() as BufferSize;
 
         let mut ptr = self.data_ptr().add(self.len());
@@ -392,24 +328,31 @@ impl<T, A: Allocator> Vector<T, A> {
     }
 
     /// Allocate a clone of this buffer.
-    pub fn clone_buffer(&self) -> Self
+    ///
+    /// The provided allocator does not need to be the one this raw vector was created with.
+    /// The returned raw vector is considered to be created with the provided allocator.
+    pub fn clone_buffer<A: Allocator>(&self, allocator: &A) -> Self
     where
         T: Clone,
         A: Clone,
     {
-        self.clone_buffer_with_capacity(self.len())
+        self.clone_buffer_with_capacity(allocator, self.len())
     }
 
     /// Allocate a clone of this buffer with a different capacity
     ///
     /// The capacity must be at least as large as the buffer's length.
-    pub fn clone_buffer_with_capacity(&self, cap: usize) -> Self
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub fn clone_buffer_with_capacity<A: Allocator>(&self, allocator: &A, cap: usize) -> Self
     where
         T: Clone,
         A: Clone,
     {
         let mut clone =
-            Self::try_with_capacity_in(cap.max(self.len()), self.allocator.clone()).unwrap();
+            Self::try_with_capacity(allocator, cap.max(self.len())).unwrap();
         let len = self.len;
 
         unsafe {
@@ -429,38 +372,38 @@ impl<T, A: Allocator> Vector<T, A> {
 
     // Note: Marking this #[inline(never)] is a pretty large regression in the push benchmark.
     #[cold]
-    fn try_realloc_additional(&mut self, additional: usize) -> Result<(), AllocError> {
+    unsafe fn try_realloc_additional<A: Allocator>(&mut self, allocator: &A, additional: usize) -> Result<(), AllocError> {
         let new_cap = grow_amortized(self.len(), additional);
         if new_cap < self.len() {
             return Err(AllocError);
         }
 
-        self.try_realloc_with_capacity(new_cap)
+        self.try_realloc_with_capacity(allocator, new_cap)
     }
 
     #[cold]
-    fn try_realloc_with_capacity(&mut self, new_cap: usize) -> Result<(), AllocError> {
+    unsafe fn try_realloc_with_capacity<A: Allocator>(&mut self, allocator: &A, new_cap: usize) -> Result<(), AllocError> {
         type R = DefaultRefCount;
 
         unsafe {
             if new_cap == 0 {
-                self.deallocate();
+                self.deallocate_buffer(allocator);
             }
 
             let new_layout = buffer_layout::<Header<R, A>, T>(new_cap).unwrap();
 
             let new_alloc = if self.cap == 0 {
-                self.allocator.allocate(new_layout)?
+                allocator.allocate(new_layout)?
             } else {
                 let old_cap = self.capacity();
-                let old_ptr = self.base_ptr();
+                let old_ptr = self.base_ptr(allocator);
                 let old_layout = buffer_layout::<Header<R, A>, T>(old_cap).unwrap();
                 let new_layout = buffer_layout::<Header<R, A>, T>(new_cap).unwrap();
 
                 if new_layout.size() >= old_layout.size() {
-                    self.allocator.grow(old_ptr, old_layout, new_layout)
+                    allocator.grow(old_ptr, old_layout, new_layout)
                 } else {
-                    self.allocator.shrink(old_ptr, old_layout, new_layout)
+                    allocator.shrink(old_ptr, old_layout, new_layout)
                 }?
             };
 
@@ -473,28 +416,486 @@ impl<T, A: Allocator> Vector<T, A> {
     }
 
     // Deallocates the memory, does not drop the vector's content.
-    unsafe fn deallocate(&mut self) {
+    unsafe fn deallocate_buffer<A: Allocator>(&mut self, allocator: &A) {
         let layout = buffer_layout::<Header<DefaultRefCount, A>, T>(self.capacity()).unwrap();
-        let ptr = self.base_ptr();
+        let ptr = self.base_ptr(allocator);
 
-        self.allocator.deallocate(ptr, layout);
+        allocator.deallocate(ptr, layout);
 
         self.cap = 0;
         self.len = 0;
         self.data = NonNull::dangling();
+    }
+
+    /// Tries to reserve at least enough space for `additional` extra items.
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    #[inline]
+    pub unsafe fn try_reserve<A: Allocator>(&mut self, allocator: &A, additional: usize) -> Result<(), AllocError> {
+        if self.remaining_capacity() < additional {
+            self.try_realloc_additional(allocator, additional)?;
+        }
+
+        Ok(())
+    }
+
+    /// Tries to reserve the minimum capacity for at least `additional` elements to be inserted in the given vector.
+    ///
+    /// Unlike `try_reserve`, this will not deliberately over-allocate to speculatively avoid frequent allocations.
+    /// After calling `reserve_exact`, capacity will be greater than or equal to `self.len() + additional`.
+    /// This will also allocate if the vector is not unique.
+    /// Does nothing if the capacity is already sufficient and the vector is unique.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore, capacity can not
+    /// be relied upon to be precisely minimal. Prefer `try_reserve` if future insertions are expected.
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn try_reserve_exact<A: Allocator>(&mut self, allocator: &A, additional: usize) -> Result<(), AllocError> {
+        if self.remaining_capacity() >= additional {
+            return Ok(());
+        }
+
+        self.try_realloc_with_capacity(allocator, self.len() + additional)
+    }
+
+    /// Shrinks the capacity of the vector with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the supplied value.
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn shrink_to<A: Allocator>(&mut self, allocator: &A, min_capacity: usize)
+    where
+        T: Clone,
+    {
+        let min_capacity = min_capacity.max(self.len());
+        if self.capacity() <= min_capacity {
+            return;
+        }
+
+        self.try_realloc_with_capacity(allocator, min_capacity).unwrap();
+    }
+
+    /// Shrinks the capacity of the vector as much as possible.
+    ///
+    /// # Safety
+    ///
+    /// The provided allocator must be the one this raw vector was created with.
+    pub unsafe fn shrink_to_fit<A: Allocator>(&mut self, allocator: &A)
+    where
+        T: Clone,
+    {
+        self.shrink_to(allocator, self.len())
+    }
+
+    /// Transfers ownership of this raw vector's contents to the one that is returned, and leaves
+    /// this one empty and unallocated.
+    pub fn take(&mut self) -> Self {
+        std::mem::replace(self, RawVector::new())
+    }
 }
 
-    #[inline]
-    pub fn reserve(&mut self, additional: usize) {
-        if self.remaining_capacity() < additional {
-            self.try_realloc_additional(additional).unwrap();
+impl<T: PartialEq<T>> PartialEq<RawVector<T>> for RawVector<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T: PartialEq<T>> PartialEq<&[T]> for RawVector<T> {
+    fn eq(&self, other: &&[T]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+impl<T> AsRef<[T]> for RawVector<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> AsMut<[T]> for RawVector<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> Default for RawVector<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a RawVector<T> {
+    type Item = &'a T;
+    type IntoIter = core::slice::Iter<'a, T>;
+    fn into_iter(self) -> core::slice::Iter<'a, T> {
+        self.as_slice().iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut RawVector<T> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> core::slice::IterMut<'a, T> {
+        self.as_mut_slice().iter_mut()
+    }
+}
+
+impl<T, I> Index<I> for RawVector<T>
+where
+    I: core::slice::SliceIndex<[T]>,
+{
+    type Output = <I as core::slice::SliceIndex<[T]>>::Output;
+    fn index(&self, index: I) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl<T, I> IndexMut<I> for RawVector<T>
+where
+    I: core::slice::SliceIndex<[T]>,
+{
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        self.as_mut_slice().index_mut(index)
+    }
+}
+
+impl<T> Deref for RawVector<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> DerefMut for RawVector<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T: Debug> Debug for RawVector<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        self.as_slice().fmt(f)
+    }
+}
+
+impl<T: core::hash::Hash> core::hash::Hash for RawVector<T> {
+    fn hash<H>(&self, state: &mut H) where H: core::hash::Hasher {
+        self.as_slice().hash(state)
+    }
+}
+
+
+/// A heap allocated, mutable contiguous buffer containing elements of type `T`.
+///
+/// <svg width="280" height="120" viewBox="0 0 74.08 31.75" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="a"><stop offset="0" stop-color="#491c9c"/><stop offset="1" stop-color="#d54b27"/></linearGradient><linearGradient xlink:href="#a" id="b" gradientUnits="userSpaceOnUse" x1="6.27" y1="34.86" x2="87.72" y2="13.24" gradientTransform="translate(-2.64 -18.48)"/></defs><rect width="10.57" height="10.66" x="7.94" y="18.45" ry="1.37" fill="#3dbdaa"/><circle cx="12.7" cy="18.48" r=".79" fill="#666"/><path d="M12.7 18.48c0-3.93 7.14-1.28 7.14-5.25" fill="none" stroke="#999" stroke-width=".86" stroke-linecap="round"/><rect width="68.79" height="10.58" x="2.65" y="2.68" ry="1.37" fill="url(#b)"/><rect width="15.35" height="9.51" x="3.18" y="3.21" ry=".9" fill="#78a2d4"/><rect width="9.26" height="9.51" x="19.85" y="3.2" ry=".9" fill="#eaa577"/><rect width="9.26" height="9.51" x="29.64" y="3.22" ry=".9" fill="#eaa577"/><rect width="9.26" height="9.51" x="39.43" y="3.22" ry=".9" fill="#eaa577"/><rect width="9.26" height="9.51" x="49.22" y="3.21" ry=".9" fill="#eaa577"/><circle cx="62.84" cy="7.97" r=".66" fill="#eaa577"/><circle cx="64.7" cy="7.97" r=".66" fill="#eaa577"/><circle cx="66.55" cy="7.97" r=".66" fill="#eaa577"/></svg>
+///
+/// Similar in principle to a `Vec<T>`.
+/// It can be converted for free into a reference counted `SharedVector<T>` or `AtomicSharedVector<T>`.
+///
+/// Unique and shared vectors expose similar functionality. `Vector` takes advantage of
+/// the guaranteed uniqueness at the type level to provide overall faster operations than its
+/// shared counterparts, while its memory layout makes it very cheap to convert to a shared vector
+/// (involving no allocation or copy).
+///
+/// # Internal representation
+///
+/// `Vector` stores its length and capacity inline and points to the first element of the
+/// allocated buffer. Room for a header is left uninitialized before the elements so that the
+/// vector can be converted into a `SharedVector` or `AtomicSharedVector` without reallocating
+/// the storage.
+///
+/// Internally, `Vector` is built on top of `RawVector`.
+pub struct Vector<T, A: Allocator = Global> {
+    pub(crate) raw: RawVector<T>,
+    pub(crate) allocator: A,
+}
+
+impl<T> Vector<T, Global> {
+    /// Creates an empty vector.
+    ///
+    /// This does not allocate memory.
+    pub fn new() -> Vector<T, Global> {
+        Vector {
+            raw: RawVector::new(),
+            allocator: Global,
         }
     }
 
+
+
+    /// Creates an empty pre-allocated vector with a given storage capacity.
+    ///
+    /// Does not allocate memory if `cap` is zero.
+    pub fn with_capacity(cap: usize) -> Vector<T, Global> {
+        Self::try_with_capacity(cap).unwrap()
+    }
+
+    /// Creates an empty pre-allocated vector with a given storage capacity.
+    ///
+    /// Does not allocate memory if `cap` is zero.
+    pub fn try_with_capacity(cap: usize) -> Result<Vector<T, Global>, AllocError> {
+        Vector::try_with_capacity_in(cap, Global)
+    }
+
+    pub fn from_slice(data: &[T]) -> Self
+    where
+        T: Clone,
+    {
+        Vector { raw: RawVector::try_from_slice(&Global, data).unwrap(), allocator: Global }
+    }
+
+    /// Creates a vector with `n` clones of `elem`.
+    pub fn from_elem(elem: T, n: usize) -> Vector<T, Global>
+    where
+        T: Clone,
+    {
+        Vector { raw: RawVector::try_from_elem(&Global, elem, n).unwrap(), allocator: Global }
+    }
+}
+
+impl<T, A: Allocator> Vector<T, A> {
+    /// Creates an empty vector without allocating memory.
+    pub fn new_in(allocator: A) -> Self {
+        Self::try_with_capacity_in(0, allocator).unwrap()
+    }
+
+    /// Creates an empty pre-allocated vector with a given storage capacity.
+    ///
+    /// Does not allocate memory if `cap` is zero.
+    pub fn with_capacity_in(cap: usize, allocator: A) -> Self {
+        Self::try_with_capacity_in(cap, allocator).unwrap()
+    }
+
+    /// Creates an empty pre-allocated vector with a given storage capacity.
+    ///
+    /// Does not allocate memory if `cap` is zero.
+    pub fn try_with_capacity_in(cap: usize, allocator: A) -> Result<Vector<T, A>, AllocError> {
+        let raw = RawVector::try_with_capacity(&allocator, cap)?;
+
+        Ok(Vector { raw, allocator })
+    }
+
+
+    #[inline(always)]
+    /// Returns `true` if the vector contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.raw.is_empty()
+    }
+
+    #[inline(always)]
+    /// Returns the number of elements in the vector, also referred to as its ‘length’.
+    pub fn len(&self) -> usize {
+        self.raw.len()
+    }
+
+    #[inline(always)]
+    /// Returns the total number of elements the vector can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.raw.capacity()
+    }
+
+    /// Returns number of elements that can be added without reallocating.
+    #[inline(always)]
+    pub fn remaining_capacity(&self) -> usize {
+        self.raw.remaining_capacity()
+    }
+
+    /// Returns a reference to the underlying allocator.
+    #[inline(always)]
+    pub fn allocator(&self) -> &A {
+        &self.allocator
+    }
+
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[T] {
+        self.raw.as_slice()
+    }
+
+    #[inline(always)]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.raw.as_mut_slice()
+    }
+
+    /// Clears the vector, removing all values.
+    pub fn clear(&mut self) {
+        self.raw.clear()
+    }
+
+    unsafe fn into_header_buffer<R>(mut self) -> HeaderBuffer<T, R, A>
+    where
+        R: RefCount,
+    {
+        debug_assert!(self.raw.cap != 0);
+        unsafe {
+            let mut header = raw::header_from_data_ptr(self.raw.data);
+
+            *header.as_mut() = raw::Header {
+                vec: VecHeader {
+                    len: self.raw.len,
+                    cap: self.raw.cap,
+                },
+                ref_count: R::new(1),
+                allocator: ptr::read(&mut self.allocator),
+            };
+
+            mem::forget(self);
+
+            HeaderBuffer::from_raw(header)
+        }
+    }
+
+    /// Make this vector immutable.
+    ///
+    /// This operation is cheap, the underlying storage does not not need
+    /// to be reallocated.
     #[inline]
-    pub fn try_reserve(&mut self, additional: usize) {
-        if self.remaining_capacity() < additional {
-            self.try_realloc_additional(additional).unwrap();
+    pub fn into_shared(self) -> SharedVector<T, A>
+    where
+        A: Allocator + Clone,
+    {
+        if self.raw.cap == 0 {
+            return SharedVector::try_with_capacity_in(0, self.allocator.clone()).unwrap();
+        }
+        unsafe {
+            let inner = self.into_header_buffer::<DefaultRefCount>();
+            SharedVector { inner }
+        }
+    }
+
+    /// Make this vector immutable.
+    ///
+    /// This operation is cheap, the underlying storage does not not need
+    /// to be reallocated.
+    #[inline]
+    pub fn into_shared_atomic(self) -> AtomicSharedVector<T, A>
+    where
+        A: Allocator + Clone,
+    {
+        if self.raw.cap == 0 {
+            return AtomicSharedVector::try_with_capacity_in(0, self.allocator.clone()).unwrap();
+        }
+        unsafe {
+            let inner = self.into_header_buffer::<AtomicRefCount>();
+            AtomicSharedVector { inner }
+        }
+    }
+
+    /// Appends an element to the back of a collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `u32::MAX` bytes.
+    #[inline(always)]
+    pub fn push(&mut self, val: T) {
+        unsafe {
+            self.raw.push(&self.allocator, val);
+        }
+    }
+
+    /// Appends an element if there is sufficient spare capacity, otherwise an error is returned
+    /// with the element.
+    ///
+    /// Unlike push this method will not reallocate when there’s insufficient capacity.
+    /// The caller should use reserve or try_reserve to ensure that there is enough capacity.
+    #[inline(always)]
+    pub fn push_within_capacity(&mut self, val: T) -> Result<(), T> {
+        self.raw.push_within_capacity(val)
+    }
+
+    /// Removes the last element from the vector and returns it, or `None` if it is empty.
+    #[inline(always)]
+    pub fn pop(&mut self) -> Option<T> {
+        self.raw.pop()
+    }
+
+    /// Removes an element from the vector and returns it.
+    ///
+    /// The removed element is replaced by the last element of the vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is out of bounds.
+    #[inline(always)]
+    pub fn swap_remove(&mut self, idx: usize) -> T {
+        self.raw.swap_remove(idx)
+    }
+
+    /// Clones and appends the contents of the slice to the back of a collection.
+    #[inline(always)]
+    pub fn extend_from_slice(&mut self, data: &[T])
+    where
+        T: Clone,
+    {
+        unsafe {
+            self.raw.extend_from_slice(&self.allocator, data)
+        }
+    }
+
+    /// Moves all the elements of `other` into `self`, leaving `other` empty.
+    #[inline(always)]
+    pub fn append(&mut self, other: &mut Self)
+    where
+        T: Clone,
+    {
+        unsafe {
+            self.raw.append(&self.allocator, &mut other.raw)
+        }
+    }
+
+    /// Appends the contents of an iterator to the back of a collection.
+    #[inline(always)]
+    pub fn extend(&mut self, data: impl IntoIterator<Item = T>) {
+        unsafe {
+            self.raw.extend(&self.allocator, data)
+        }
+    }
+
+    /// Allocates a clone of this buffer.
+    #[inline(always)]
+    pub fn clone_buffer(&self) -> Self
+    where
+        T: Clone,
+        A: Clone,
+    {
+        Vector {
+            raw: self.raw.clone_buffer(&self.allocator),
+            allocator: self.allocator.clone(),
+        }
+    }
+
+    /// Allocate a clone of this buffer with a different capacity
+    ///
+    /// The capacity must be at least as large as the buffer's length.
+    #[inline(always)]
+    pub fn clone_buffer_with_capacity(&self, cap: usize) -> Self
+    where
+        T: Clone,
+        A: Clone,
+    {
+        Vector {
+            raw: self.raw.clone_buffer_with_capacity(&self.allocator, cap),
+            allocator: self.allocator.clone(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn reserve(&mut self, additional: usize) {
+        unsafe {
+            self.raw.try_reserve(&self.allocator, additional).unwrap()
+        }
+    }
+
+    #[inline(always)]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        unsafe {
+            self.raw.try_reserve(&self.allocator, additional)
         }
     }
 
@@ -525,51 +926,45 @@ impl<T, A: Allocator> Vector<T, A> {
     /// Note that the allocator may give the collection more space than it requests. Therefore, capacity can not
     /// be relied upon to be precisely minimal. Prefer `try_reserve` if future insertions are expected.
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), AllocError> {
-        if self.remaining_capacity() >= additional {
-            return Ok(());
+        unsafe {
+            self.raw.try_reserve_exact(&self.allocator, additional)
         }
-
-        self.try_realloc_with_capacity(self.len() + additional)
     }
 
     /// Shrinks the capacity of the vector with a lower bound.
     ///
     /// The capacity will remain at least as large as both the length and the supplied value.
     /// If the current capacity is less than the lower limit, this is a no-op.
+    #[inline(always)]
     pub fn shrink_to(&mut self, min_capacity: usize)
     where
         T: Clone,
     {
-        let min_capacity = min_capacity.max(self.len());
-        if self.capacity() <= min_capacity {
-            return;
+        unsafe {
+            self.raw.shrink_to(&self.allocator, min_capacity)
         }
-
-        self.try_realloc_with_capacity(min_capacity).unwrap();
     }
 
     /// Shrinks the capacity of the vector as much as possible.
+    #[inline(always)]
     pub fn shrink_to_fit(&mut self)
     where
         T: Clone,
     {
-        self.shrink_to(self.len())
+        unsafe {
+            self.raw.shrink_to_fit(&self.allocator)
+        }
     }
 
+    #[inline(always)]
     pub fn take(&mut self) -> Self
     where
         A: Clone,
     {
         let other = Vector {
-            data: self.data,
-            len: self.len,
-            cap: self.cap,
+            raw: self.raw.take(),
             allocator: self.allocator.clone(),
         };
-
-        self.data = NonNull::dangling();
-        self.len = 0;
-        self.cap = 0;
 
         other
     }
@@ -577,14 +972,8 @@ impl<T, A: Allocator> Vector<T, A> {
 
 impl<T, A: Allocator> Drop for Vector<T, A> {
     fn drop(&mut self) {
-        if self.cap == 0 {
-            return;
-        }
-
-        self.clear();
-
         unsafe {
-            self.deallocate();
+            self.raw.deallocate(&self.allocator)
         }
     }
 }
@@ -595,25 +984,25 @@ impl<T: Clone, A: Allocator + Clone> Clone for Vector<T, A> {
     }
 }
 
-impl<T: PartialEq<T>, A: Allocator + Clone> PartialEq<Vector<T, A>> for Vector<T, A> {
+impl<T: PartialEq<T>, A: Allocator> PartialEq<Vector<T, A>> for Vector<T, A> {
     fn eq(&self, other: &Self) -> bool {
         self.as_slice() == other.as_slice()
     }
 }
 
-impl<T: PartialEq<T>, A: Allocator + Clone> PartialEq<&[T]> for Vector<T, A> {
+impl<T: PartialEq<T>, A: Allocator> PartialEq<&[T]> for Vector<T, A> {
     fn eq(&self, other: &&[T]) -> bool {
         self.as_slice() == *other
     }
 }
 
-impl<T, A: Allocator + Clone> AsRef<[T]> for Vector<T, A> {
+impl<T, A: Allocator> AsRef<[T]> for Vector<T, A> {
     fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
 }
 
-impl<T, A: Allocator + Clone> AsMut<[T]> for Vector<T, A> {
+impl<T, A: Allocator> AsMut<[T]> for Vector<T, A> {
     fn as_mut(&mut self) -> &mut [T] {
         self.as_mut_slice()
     }
@@ -625,7 +1014,7 @@ impl<T> Default for Vector<T, Global> {
     }
 }
 
-impl<'a, T, A: Allocator + Clone> IntoIterator for &'a Vector<T, A> {
+impl<'a, T, A: Allocator> IntoIterator for &'a Vector<T, A> {
     type Item = &'a T;
     type IntoIter = core::slice::Iter<'a, T>;
     fn into_iter(self) -> core::slice::Iter<'a, T> {
@@ -633,7 +1022,7 @@ impl<'a, T, A: Allocator + Clone> IntoIterator for &'a Vector<T, A> {
     }
 }
 
-impl<'a, T, A: Allocator + Clone> IntoIterator for &'a mut Vector<T, A> {
+impl<'a, T, A: Allocator> IntoIterator for &'a mut Vector<T, A> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;
     fn into_iter(self) -> core::slice::IterMut<'a, T> {
@@ -641,7 +1030,7 @@ impl<'a, T, A: Allocator + Clone> IntoIterator for &'a mut Vector<T, A> {
     }
 }
 
-impl<T, A: Allocator + Clone, I> Index<I> for Vector<T, A>
+impl<T, A: Allocator, I> Index<I> for Vector<T, A>
 where
     I: core::slice::SliceIndex<[T]>,
 {
@@ -651,7 +1040,7 @@ where
     }
 }
 
-impl<T, A: Allocator + Clone, I> IndexMut<I> for Vector<T, A>
+impl<T, A: Allocator, I> IndexMut<I> for Vector<T, A>
 where
     I: core::slice::SliceIndex<[T]>,
 {
@@ -660,20 +1049,20 @@ where
     }
 }
 
-impl<T, A: Allocator + Clone> Deref for Vector<T, A> {
+impl<T, A: Allocator> Deref for Vector<T, A> {
     type Target = [T];
     fn deref(&self) -> &[T] {
         self.as_slice()
     }
 }
 
-impl<T, A: Allocator + Clone> DerefMut for Vector<T, A> {
+impl<T, A: Allocator> DerefMut for Vector<T, A> {
     fn deref_mut(&mut self) -> &mut [T] {
         self.as_mut_slice()
     }
 }
 
-impl<T: Debug, A: Allocator + Clone> Debug for Vector<T, A> {
+impl<T: Debug, A: Allocator> Debug for Vector<T, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         self.as_slice().fmt(f)
     }
@@ -797,4 +1186,47 @@ fn zst() {
     v.push(());
 
     assert_eq!(v.len(), 4);
+}
+
+#[test]
+fn dyn_allocator() {
+    let allocator: &dyn Allocator = &Global;
+    let mut v = crate::vector!([1u32, 2, 3] in allocator);
+
+    v.push(4);
+
+    assert_eq!(&v[..], &[1, 2, 3, 4]);
+}
+
+#[test]
+fn borrowd_dyn_alloc() {
+    struct DataStructure<'a> {
+        data: Vector<u32, &'a dyn Allocator>,
+    }
+
+    impl DataStructure<'static> {
+        fn new() -> DataStructure<'static> {
+            DataStructure {
+                data: Vector::new_in(&Global as &'static dyn Allocator)
+            }
+        }
+    }
+
+    impl<'a> DataStructure<'a> {
+        fn new_in(allocator: &'a dyn Allocator) -> DataStructure<'a> {
+            DataStructure { data: Vector::new_in(allocator) }
+        }
+
+        fn push(&mut self, val: u32) {
+            self.data.push(val);
+        }
+    }
+
+    let mut ds1 = DataStructure::new();
+    ds1.push(1);
+
+    let alloc = Global; 
+    let mut ds2 = DataStructure::new_in(&alloc);
+    ds2.push(2);
+
 }


### PR DESCRIPTION
RawVector contains most of Vector's logic, except that it does not store an allocator. The latter has to be passed manually to functions that may neeed to interact with it. Most of these functions rely on the allocator to be the same as the one the raw vector was created with so they are marked as unsafe.