### PR TITLE
Add `IntoIterator` impl for `Vector<T>`

### DIFF
--- a/src/intoiter.rs
+++ b/src/intoiter.rs
@@ -1,0 +1,114 @@
+use std::{
+    mem,
+    ptr::{self, NonNull},
+};
+
+use crate::{RawVector, Vector};
+
+pub struct IntoIter<T> {
+    _buf: RawVector<T>, // we don't actually care about this. Just need it to live.
+    iter: RawValIter<T>,
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        self.iter.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<T> DoubleEndedIterator for IntoIter<T> {
+    fn next_back(&mut self) -> Option<T> {
+        self.iter.next_back()
+    }
+}
+
+impl<T> ExactSizeIterator for IntoIter<T> {}
+
+impl<T> Drop for IntoIter<T> {
+    fn drop(&mut self) {
+        for _ in &mut *self {}
+    }
+}
+
+impl<T> IntoIterator for Vector<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> IntoIter<T> {
+        let (iter, buf) = unsafe { (RawValIter::new(&self), ptr::read(&self.raw)) };
+
+        mem::forget(self);
+
+        IntoIter { iter, _buf: buf }
+    }
+}
+
+struct RawValIter<T> {
+    start: *const T,
+    end: *const T,
+}
+
+impl<T> RawValIter<T> {
+    unsafe fn new(slice: &[T]) -> Self {
+        RawValIter {
+            start: slice.as_ptr(),
+            end: if mem::size_of::<T>() == 0 {
+                ((slice.as_ptr() as usize) + slice.len()) as *const _
+            } else if slice.len() == 0 {
+                slice.as_ptr()
+            } else {
+                slice.as_ptr().add(slice.len())
+            },
+        }
+    }
+}
+
+impl<T> Iterator for RawValIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        if self.start == self.end {
+            None
+        } else {
+            unsafe {
+                if mem::size_of::<T>() == 0 {
+                    self.start = (self.start as usize + 1) as *const _;
+                    Some(ptr::read(NonNull::<T>::dangling().as_ptr()))
+                } else {
+                    let old_ptr = self.start;
+                    self.start = self.start.offset(1);
+                    Some(ptr::read(old_ptr))
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let elem_size = mem::size_of::<T>();
+        let len =
+            (self.end as usize - self.start as usize) / if elem_size == 0 { 1 } else { elem_size };
+        (len, Some(len))
+    }
+}
+
+impl<T> DoubleEndedIterator for RawValIter<T> {
+    fn next_back(&mut self) -> Option<T> {
+        if self.start == self.end {
+            None
+        } else {
+            unsafe {
+                if mem::size_of::<T>() == 0 {
+                    self.end = (self.end as usize - 1) as *const _;
+                    Some(ptr::read(NonNull::<T>::dangling().as_ptr()))
+                } else {
+                    self.end = self.end.offset(-1);
+                    Some(ptr::read(self.end))
+                }
+            }
+        }
+    }
+}
+
+impl<T> ExactSizeIterator for RawValIter<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,18 @@
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 #![doc = include_str!("../README.md")]
 
+mod drain;
+mod intoiter;
 mod raw;
 mod shared;
-mod vector;
-mod drain;
 mod splice;
+mod vector;
 
 pub use raw::{AtomicRefCount, BufferSize, DefaultRefCount, RefCount};
 pub use shared::{AtomicSharedVector, RefCountedVector, SharedVector};
-pub use vector::{Vector, RawVector};
+pub use vector::{RawVector, Vector};
+
+pub use intoiter::IntoIter;
 
 pub mod alloc {
     pub use allocator_api2::alloc::{AllocError, Allocator, Global};

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -30,7 +30,9 @@ pub struct VecHeader {
 }
 
 impl VecHeader {
-    fn remaining_capacity(&self) -> u32 { self.cap - self.len }
+    fn remaining_capacity(&self) -> u32 {
+        self.cap - self.len
+    }
 }
 
 #[repr(C)]
@@ -173,8 +175,13 @@ impl<T, R: RefCount, A: Allocator> HeaderBuffer<T, R, A> {
     }
 }
 
-pub unsafe fn move_data<T>(src_data: *mut T, src_vec: &mut VecHeader, dst_data: *mut T, dst_vec: &mut VecHeader) {
-    debug_assert!(dst_vec.cap - dst_vec.len  >= src_vec.len);
+pub unsafe fn move_data<T>(
+    src_data: *mut T,
+    src_vec: &mut VecHeader,
+    dst_data: *mut T,
+    dst_vec: &mut VecHeader,
+) {
+    debug_assert!(dst_vec.cap - dst_vec.len >= src_vec.len);
     let len = src_vec.len;
     if len > 0 {
         unsafe {
@@ -189,8 +196,11 @@ pub unsafe fn move_data<T>(src_data: *mut T, src_vec: &mut VecHeader, dst_data: 
     }
 }
 
-pub unsafe fn extend_from_slice_assuming_capacity<T: Clone>(data: *mut T, vec: &mut VecHeader, slice: &[T])
-where
+pub unsafe fn extend_from_slice_assuming_capacity<T: Clone>(
+    data: *mut T,
+    vec: &mut VecHeader,
+    slice: &[T],
+) where
     T: Clone,
 {
     let len = slice.len() as u32;
@@ -209,7 +219,11 @@ where
 }
 
 // Returns true if the iterator was emptied.
-pub unsafe fn extend_within_capacity<T, I: Iterator<Item = T>>(data: *mut T, vec: &mut VecHeader, iter: &mut I) -> bool {
+pub unsafe fn extend_within_capacity<T, I: Iterator<Item = T>>(
+    data: *mut T,
+    vec: &mut VecHeader,
+    iter: &mut I,
+) -> bool {
     let inital_len = vec.len;
 
     let mut ptr = data.add(inital_len as usize);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1671,18 +1671,3 @@ fn drain1() {
     let end = 16059518370053021185.min(len);
     vectors[2].drain(start..end);
 }
-
-#[test]
-fn into_iter() {
-    let mut vector = Vector::new();
-    vector.push(10);
-    vector.push(20);
-    vector.push(30);
-    vector.push(40);
-    vector.push(50);
-    vector.push(60);
-
-    let res = vector.into_iter().collect::<Vec<_>>();
-
-    dbg!(res);
-}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -129,6 +129,19 @@ impl<T> RawVector<T> {
         self.header.len = 0;
     }
 
+    pub unsafe fn deallocate_no_drop<A: Allocator>(&mut self, allocator: &A) {
+        if self.header.cap == 0 {
+            return;
+        }
+
+        self.clear_without_drop();
+        self.deallocate_buffer(allocator);
+
+        self.data = NonNull::dangling();
+        self.header.cap = 0;
+        self.header.len = 0;
+    }
+
     #[inline]
     /// Returns `true` if the vector contains no elements.
     pub fn is_empty(&self) -> bool {
@@ -171,6 +184,10 @@ impl<T> RawVector<T> {
     /// Clears the vector, removing all values.
     pub fn clear(&mut self) {
         unsafe { raw::clear(self.data_ptr(), &mut self.header) }
+    }
+
+    pub fn clear_without_drop(&mut self) {
+        self.header.len = 0;
     }
 
     unsafe fn base_ptr<A: Allocator>(&self, _allocator: &A) -> NonNull<u8> {


### PR DESCRIPTION
I needed an iterator that consumed the vector by value rather than getting it by reference. I followed the implementation from the rust nomicon. Locally all the tests pass and the miri tests pass minus the existing failure for `drain1`.

It looks like rust fmt ran on the whole repo - if you'd like I can adjust the diff to just include the changes from the one additional file if you'd like.

Happy to make any other changes as needed.